### PR TITLE
Update sidebar, options, add hook "MenuVGUIReady"

### DIFF
--- a/lua/menu_plugins/init.lua
+++ b/lua/menu_plugins/init.lua
@@ -6,14 +6,21 @@ menup = {} --we will store menu plugin functions/vars here
 for k, fil in pairs(file.Find("lua/menu_plugins/modules/*.lua", "GAME")) do
 	if fil == "init.lua" then continue end
 
+	MsgC(Color(0, 0, 255), "Loading module '"..fil.."'...")
 	include("menu_plugins/modules/"..fil)
 end
 
 for k, fil in pairs(file.Find("lua/menu_plugins/*.lua", "GAME")) do
 	if fil == "init.lua" then continue end
 
+	MsgC(Color(0, 0, 255), "Loading module '"..fil.."'...")
 	menup.include(fil)
 end
 
 MsgC(Color(0, 255, 00), "All menu plugins loaded!\n")
 MsgC("\n")
+
+hook.Add("DrawOverlay", "MenuVGUIReady", function()
+	hook.Run("MenuVGUIReady")
+	hook.Remove("DrawOverlay", "MenuVGUIReady")
+end)

--- a/lua/menu_plugins/modules/options.lua
+++ b/lua/menu_plugins/modules/options.lua
@@ -20,7 +20,7 @@ end
 local function setOption(ply, cmd, args)
 	menup.options.setOption(args[1], args[2], args[3])
 end
-concommand.Add("menup_setOption", setOption)
+concommand.Add("menup_setOption", setOption, nil, "Set a menu state option; Format: <plugin> <option> <value>")
 
 local function spewOptions()
 	for plugin, tab in pairs(options) do
@@ -30,4 +30,8 @@ local function spewOptions()
 		end
 	end
 end
-concommand.Add("menup_spewOptions", spewOptions)
+concommand.Add("menup_spewOptions", spewOptions, nil, "Spew all menu state options")
+
+function menup.options.getTable()
+	return options
+end

--- a/lua/menu_plugins/modules/sidebar.lua
+++ b/lua/menu_plugins/modules/sidebar.lua
@@ -12,16 +12,29 @@ function PANEL:Init()
 	self:SetDraggable(false)
 	self:SetTitle("")
 
+	self.textentry = vgui.Create("DTextEntry", self)
+	self.textentry:Dock(BOTTOM)
+	self.textentry.OnEnter = function(self2)
+		if not self.curoption then return end
+		menup.options.setOption(self.curoption[1], self.curoption[2], self2:GetText())
+	end
+
 	self.tree = vgui.Create("DTree", self)
 	self.tree:Dock(FILL)
+	self.tree.OnNodeSelected = function(self2, node)
+		local parent = node:GetParentNode()
+		if parent == self2:Root() then return end
+		self.textentry:SetText(menup.options.getOption(parent:GetText(), node:GetText()))
+		self.curoption = {parent:GetText(), node:GetText()}
+	end
 
 	self.out = false
 	self:KillFocus()
 
 	self.plugins = {}
 end
-function PANEL:Moove(outin)
 
+function PANEL:Moove(outin)
 	if outin == OUT and not self.out then
 		self:MoveTo(ScrW(), select(2, self:GetPos()), .1, 0, 2)
 		self.out = true
@@ -50,6 +63,18 @@ function PANEL:AddOption(plugin, option, type)
 		self.plugins[plugin].options = {}
 		self.plugins[plugin].node = self.tree:AddNode(plugin, "icon16/wrench.png")
 	end
+	self.plugins[plugin].node:AddNode(option, "icon16/information.png")
 end
 
 derma.DefineControl("menupSidebar", "Sidebar for Menu Plugins", PANEL, "DFrame")
+
+hook.Add("MenuVGUIReady", "MenuP_CreateSidebar", function()
+	menup.sidebar = vgui.Create("menupSidebar")
+	menup.sidebar:MakePopup()
+
+	for plugin, options in pairs(menup.options.getTable()) do
+		for option, _ in pairs(options) do
+			menup.sidebar:AddOption(plugin, option)
+		end
+	end
+end)


### PR DESCRIPTION
- The sidebar now opens by default again
- The sidebar now lists options
- Clicking on an option in the sidebar will fill in a DTextEntry with the current value; editing that value and entering in the DTextEntry will set the option to the value
<br><br>To accomplish these changes, modifications had to be made to both options and init:
<br><br>Options:
- Added menup.options.getTable() which returns the local options table
- Added help text to concommands
<br>Init:
- Added hook: MenuVGUIReady (when it's ok to add vgui to the menu; used to create the sidebar)
- Added "Loading module 'x'..." message when including a module's file in init